### PR TITLE
Fix typo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ urllib3>=1.26.0
 # asyncio is built-in to Python 3.7+
 
 # Optional: for better error handling and logging
-colorlog>=6.7.0 w
+colorlog>=6.7.0


### PR DESCRIPTION
## Summary
- Fixed a typo in requirements.txt where the colorlog dependency had a trailing 'w' character
- This was preventing successful pip installation with an "Invalid requirement" error

## Test plan
- [x] Run `pip install -r requirements.txt` to verify it installs successfully
- [x] All packages install without errors

🤖 Generated with [Claude Code](https://claude.ai/code)